### PR TITLE
Add meta description for whole site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,9 +31,14 @@ header:
 
 email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  The Institute of Computing for Climate Science
+  studies and supports the role of software engineering, computer science,
+  artificial intelligence, and data science within climate science.
+  
+  The institute comprises a collaboration between Cambridge Zero,
+  the Departments of Computer Science and Technology, Applied Mathematics
+  and Theoretical Physics, and University Information Services at the
+  University of Cambridge.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: Cambridge_ICCS


### PR DESCRIPTION
The description is taken from the first few paragraphs of the home page.
fixes #6 